### PR TITLE
Feature/mensagem sobre atualizacao

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.4
+
+ARG user
+ARG uid
+
+RUN test -n "$user"
+RUN test -n "$uid"
+
+RUN apt-get update && apt-get install -y \
+poppler-utils \
+&& rm -rf /var/lib/apt/lists/*
+
+RUN adduser --gecos "$user" --uid "$uid" --disabled-login "$user"
+
+WORKDIR "/home/$user/pyboleto"
+
+USER "$user"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.5'
+
+services:
+  test:
+    command: "python setup.py test"
+    volumes:
+      - .:${HOME}/pyboleto
+    build:
+      context: .
+      args:
+        user: ${USER}
+        uid: ${UID}
+

--- a/pyboleto/pdf.py
+++ b/pyboleto/pdf.py
@@ -1092,32 +1092,33 @@ class BoletoPDF(object):
         self.pdf_canvas.drawString(1.1 * cm, 25.7 * cm, boleto_dados.instrucoes[0])
         self.pdf_canvas.drawString(1.1 * cm, 25.3*cm, boleto_dados.instrucoes[1])
 
-        # if boleto_dados.max_dias_apos_vencimento < 1:
-        #     boleto_dados.mensagem_recebimento = 'Não receber após o vencimento'
-        # else:
-        #     boleto_dados.mensagem_recebimento =\
-        #         'Não receber após {} dias do vencimento'.format(
-        #             boleto_dados.max_dias_apos_vencimento
-        #             )
+        if boleto_dados.codigo_banco == '341':
+            style = getSampleStyleSheet()['Normal']
+            style.fontName = "Helvetica"
+            style.fontSize = 9
 
-        # self.pdf_canvas.drawString(1.1 * cm, 24.75*cm, boleto_dados.mensagem_recebimento)
-        # self.pdf_canvas.drawString(1.1 * cm, 24.35*cm, 'Não aceitar pagamento com cheque')
+            link = 'https://www.itau.com.br/servicos/boletos/atualizar/'
 
-        style = getSampleStyleSheet()['Normal']
-        style.fontName = "Helvetica"
-        style.fontSize = 9
+            text_content = (
+                "Após o vencimento, atualize seu boleto em: <a color='blue' href='" + link + "'><u>" + link + "</u></a><br />"
+                "Esse boleto depende do registro no banco emissor.<br />"
+                "Caso não consiga pagar imediatamente, por favor, tente mais tarde."
+            )
 
-        link = 'https://www.itau.com.br/servicos/boletos/atualizar/'
+            text = Paragraph(text_content, style=style)
+            text.wrapOn(self.pdf_canvas, 14 * cm, 0)
+            text.drawOn(self.pdf_canvas, 1.1 * cm, 24.35*cm)
+        else:
+            if boleto_dados.max_dias_apos_vencimento < 1:
+                boleto_dados.mensagem_recebimento = 'Não receber após o vencimento'
+            else:
+                boleto_dados.mensagem_recebimento =\
+                    'Não receber após {} dias do vencimento'.format(
+                        boleto_dados.max_dias_apos_vencimento
+                        )
 
-        text_content = (
-            "Após o vencimento, atualize seu boleto em: <a color='blue' href='" + link + "'><u>" + link + "</u></a><br />"
-            "Esse boleto depende do registro no banco emissor.<br />"
-            "Caso não consiga pagar imediatamente, por favor, tente mais tarde."
-        )
-
-        text = Paragraph(text_content, style=style)
-        text.wrapOn(self.pdf_canvas, 14 * cm, 0)
-        text.drawOn(self.pdf_canvas, 1.1 * cm, 24.35*cm)
+            self.pdf_canvas.drawString(1.1 * cm, 24.75*cm, boleto_dados.mensagem_recebimento)
+            self.pdf_canvas.drawString(1.1 * cm, 24.35*cm, 'Não aceitar pagamento com cheque')
 
         self.pdf_canvas.setFont("Helvetica", 6)
         self.pdf_canvas.drawString(15.1 * cm, 27.5*cm, "(-) Descontos / Abatimentos")

--- a/pyboleto/pdf.py
+++ b/pyboleto/pdf.py
@@ -1110,7 +1110,7 @@ class BoletoPDF(object):
         link = 'https://www.itau.com.br/servicos/boletos/atualizar/'
 
         text_content = (
-            "Após o vencimento, atualize seu boleto em: <a href=" + link + ">" + link + "</a><br />"
+            "Após o vencimento, atualize seu boleto em: <a color='blue' href='" + link + "'><u>" + link + "</u></a><br />"
             "Esse boleto depende do registro no banco emissor.<br />"
             "Caso não consiga pagar imediatamente, por favor, tente mais tarde."
         )

--- a/pyboleto/pdf.py
+++ b/pyboleto/pdf.py
@@ -1092,13 +1092,17 @@ class BoletoPDF(object):
         self.pdf_canvas.drawString(1.1 * cm, 25.7 * cm, boleto_dados.instrucoes[0])
         self.pdf_canvas.drawString(1.1 * cm, 25.3*cm, boleto_dados.instrucoes[1])
 
-        if boleto_dados.max_dias_apos_vencimento < 1:
-            boleto_dados.mensagem_recebimento = 'Não receber após o vencimento'
-        else:
-            boleto_dados.mensagem_recebimento =\
-                'Não receber após {} dias do vencimento'.format(
-                    boleto_dados.max_dias_apos_vencimento
-                    )
+        # if boleto_dados.max_dias_apos_vencimento < 1:
+        #     boleto_dados.mensagem_recebimento = 'Não receber após o vencimento'
+        # else:
+        #     boleto_dados.mensagem_recebimento =\
+        #         'Não receber após {} dias do vencimento'.format(
+        #             boleto_dados.max_dias_apos_vencimento
+        #             )
+
+        # self.pdf_canvas.drawString(1.1 * cm, 24.75*cm, boleto_dados.mensagem_recebimento)
+        # self.pdf_canvas.drawString(1.1 * cm, 24.35*cm, 'Não aceitar pagamento com cheque')
+
         style = getSampleStyleSheet()['Normal']
         style.fontName = "Helvetica"
         style.fontSize = 9
@@ -1115,8 +1119,6 @@ class BoletoPDF(object):
         text.wrapOn(self.pdf_canvas, 14 * cm, 0)
         text.drawOn(self.pdf_canvas, 1.1 * cm, 24.35*cm)
 
-        self.pdf_canvas.drawString(1.1 * cm, 24.75*cm, boleto_dados.mensagem_recebimento)
-        self.pdf_canvas.drawString(1.1 * cm, 24.35*cm, 'Não aceitar pagamento com cheque')
         self.pdf_canvas.setFont("Helvetica", 6)
         self.pdf_canvas.drawString(15.1 * cm, 27.5*cm, "(-) Descontos / Abatimentos")
         self._af_draw_box_sm(4, margin_left=15)

--- a/pyboleto/pdf.py
+++ b/pyboleto/pdf.py
@@ -17,6 +17,8 @@ from reportlab.lib.pagesizes import A4, landscape as pagesize_landscape
 from reportlab.lib.units import mm, cm
 from reportlab.pdfbase.pdfmetrics import stringWidth
 from reportlab.pdfgen import canvas
+from reportlab.platypus import Paragraph
+from reportlab.lib.styles import getSampleStyleSheet
 
 
 class BoletoPDF(object):
@@ -1097,6 +1099,21 @@ class BoletoPDF(object):
                 'Não receber após {} dias do vencimento'.format(
                     boleto_dados.max_dias_apos_vencimento
                     )
+        style = getSampleStyleSheet()['Normal']
+        style.fontName = "Helvetica"
+        style.fontSize = 9
+
+        link = 'https://www.itau.com.br/servicos/boletos/atualizar/'
+
+        text_content = (
+            "Após o vencimento, atualize seu boleto em: <a href=" + link + ">" + link + "</a><br />"
+            "Esse boleto depende do registro no banco emissor.<br />"
+            "Caso não consiga pagar imediatamente, por favor, tente mais tarde."
+        )
+
+        text = Paragraph(text_content, style=style)
+        text.wrapOn(self.pdf_canvas, 14 * cm, 0)
+        text.drawOn(self.pdf_canvas, 1.1 * cm, 24.35*cm)
 
         self.pdf_canvas.drawString(1.1 * cm, 24.75*cm, boleto_dados.mensagem_recebimento)
         self.pdf_canvas.drawString(1.1 * cm, 24.35*cm, 'Não aceitar pagamento com cheque')

--- a/tests/xml/BoletoItau-expected.xml
+++ b/tests/xml/BoletoItau-expected.xml
@@ -6,6 +6,7 @@
     <fontspec color="#000000" family="Helvetica" id="3" size="15" />
     <fontspec color="#000000" family="Helvetica" id="4" size="7" />
     <fontspec color="#000000" family="Helvetica" id="5" size="11" />
+    <fontspec color="#0000ff" family="Helvetica" id="6" size="11" />
     <text font="0" height="22" left="64" top="-284" width="292">
       <b>Instru&#231;&#245;es de Pagamento</b>
     </text>
@@ -89,8 +90,12 @@
     <text font="4" height="8" left="47" top="546" width="215">Instru&#231;&#245;es (texto de responsabilidade do Benefici&#225;rio)</text>
     <text font="5" height="12" left="47" top="564" width="8">  </text>
     <text font="5" height="12" left="47" top="581" width="514">&#233; o prestador dos servi&#231;os cujo pagamento ser&#225; efetuado por este boleto, gerado por </text>
-    <text font="5" height="12" left="47" top="660" width="246">N&#227;o receber ap&#243;s 15 dias do vencimento</text>
-    <text font="5" height="12" left="47" top="677" width="218">N&#227;o aceitar pagamento com cheque</text>
+    <text font="5" height="12" left="47" top="636" width="265">Ap&#243;s o vencimento, atualize seu boleto em: </text>
+    <text font="6" height="12" left="312" top="636" width="299">
+      <a href="https://www.itau.com.br/servicos/boletos/atualizar/">https://www.itau.com.br/servicos/boletos/atualizar/</a>
+    </text>
+    <text font="5" height="12" left="47" top="654" width="308">Esse boleto depende do registro no banco emissor.</text>
+    <text font="5" height="12" left="47" top="672" width="407">Caso n&#227;o consiga pagar imediatamente, por favor, tente mais tarde.</text>
     <text font="4" height="8" left="642" top="546" width="112">(-) Descontos / Abatimentos</text>
     <text font="4" height="8" left="642" top="576" width="80">(-) Outras dedu&#231;&#245;es</text>
     <text font="4" height="8" left="642" top="606" width="64">(+) Mora / Multa</text>

--- a/tests/xml/Triplo-BoletoItau-expected.xml
+++ b/tests/xml/Triplo-BoletoItau-expected.xml
@@ -6,6 +6,7 @@
     <fontspec color="#000000" family="Helvetica" id="3" size="15" />
     <fontspec color="#000000" family="Helvetica" id="4" size="7" />
     <fontspec color="#000000" family="Helvetica" id="5" size="11" />
+    <fontspec color="#0000ff" family="Helvetica" id="6" size="11" />
     <text font="0" height="22" left="64" top="-284" width="292">
       <b>Instru&#231;&#245;es de Pagamento</b>
     </text>
@@ -89,8 +90,12 @@
     <text font="4" height="8" left="47" top="546" width="215">Instru&#231;&#245;es (texto de responsabilidade do Benefici&#225;rio)</text>
     <text font="5" height="12" left="47" top="564" width="8">  </text>
     <text font="5" height="12" left="47" top="581" width="514">&#233; o prestador dos servi&#231;os cujo pagamento ser&#225; efetuado por este boleto, gerado por </text>
-    <text font="5" height="12" left="47" top="660" width="246">N&#227;o receber ap&#243;s 15 dias do vencimento</text>
-    <text font="5" height="12" left="47" top="677" width="218">N&#227;o aceitar pagamento com cheque</text>
+    <text font="5" height="12" left="47" top="636" width="265">Ap&#243;s o vencimento, atualize seu boleto em: </text>
+    <text font="6" height="12" left="312" top="636" width="299">
+      <a href="https://www.itau.com.br/servicos/boletos/atualizar/">https://www.itau.com.br/servicos/boletos/atualizar/</a>
+    </text>
+    <text font="5" height="12" left="47" top="654" width="308">Esse boleto depende do registro no banco emissor.</text>
+    <text font="5" height="12" left="47" top="672" width="407">Caso n&#227;o consiga pagar imediatamente, por favor, tente mais tarde.</text>
     <text font="4" height="8" left="642" top="546" width="112">(-) Descontos / Abatimentos</text>
     <text font="4" height="8" left="642" top="576" width="80">(-) Outras dedu&#231;&#245;es</text>
     <text font="4" height="8" left="642" top="606" width="64">(+) Mora / Multa</text>
@@ -187,8 +192,12 @@
     <text font="4" height="8" left="47" top="546" width="215">Instru&#231;&#245;es (texto de responsabilidade do Benefici&#225;rio)</text>
     <text font="5" height="12" left="47" top="564" width="8">  </text>
     <text font="5" height="12" left="47" top="581" width="514">&#233; o prestador dos servi&#231;os cujo pagamento ser&#225; efetuado por este boleto, gerado por </text>
-    <text font="5" height="12" left="47" top="660" width="246">N&#227;o receber ap&#243;s 15 dias do vencimento</text>
-    <text font="5" height="12" left="47" top="677" width="218">N&#227;o aceitar pagamento com cheque</text>
+    <text font="5" height="12" left="47" top="636" width="265">Ap&#243;s o vencimento, atualize seu boleto em: </text>
+    <text font="6" height="12" left="312" top="636" width="299">
+      <a href="https://www.itau.com.br/servicos/boletos/atualizar/">https://www.itau.com.br/servicos/boletos/atualizar/</a>
+    </text>
+    <text font="5" height="12" left="47" top="654" width="308">Esse boleto depende do registro no banco emissor.</text>
+    <text font="5" height="12" left="47" top="672" width="407">Caso n&#227;o consiga pagar imediatamente, por favor, tente mais tarde.</text>
     <text font="4" height="8" left="642" top="546" width="112">(-) Descontos / Abatimentos</text>
     <text font="4" height="8" left="642" top="576" width="80">(-) Outras dedu&#231;&#245;es</text>
     <text font="4" height="8" left="642" top="606" width="64">(+) Mora / Multa</text>
@@ -285,8 +294,12 @@
     <text font="4" height="8" left="47" top="546" width="215">Instru&#231;&#245;es (texto de responsabilidade do Benefici&#225;rio)</text>
     <text font="5" height="12" left="47" top="564" width="8">  </text>
     <text font="5" height="12" left="47" top="581" width="514">&#233; o prestador dos servi&#231;os cujo pagamento ser&#225; efetuado por este boleto, gerado por </text>
-    <text font="5" height="12" left="47" top="660" width="246">N&#227;o receber ap&#243;s 15 dias do vencimento</text>
-    <text font="5" height="12" left="47" top="677" width="218">N&#227;o aceitar pagamento com cheque</text>
+    <text font="5" height="12" left="47" top="636" width="265">Ap&#243;s o vencimento, atualize seu boleto em: </text>
+    <text font="6" height="12" left="312" top="636" width="299">
+      <a href="https://www.itau.com.br/servicos/boletos/atualizar/">https://www.itau.com.br/servicos/boletos/atualizar/</a>
+    </text>
+    <text font="5" height="12" left="47" top="654" width="308">Esse boleto depende do registro no banco emissor.</text>
+    <text font="5" height="12" left="47" top="672" width="407">Caso n&#227;o consiga pagar imediatamente, por favor, tente mais tarde.</text>
     <text font="4" height="8" left="642" top="546" width="112">(-) Descontos / Abatimentos</text>
     <text font="4" height="8" left="642" top="576" width="80">(-) Outras dedu&#231;&#245;es</text>
     <text font="4" height="8" left="642" top="606" width="64">(+) Mora / Multa</text>


### PR DESCRIPTION
## Problema
Conforme descrito na issue #210

### [Conciliação Bancaria [DF- 92]](https://g1gck5tvei.execute-api.us-east-1.amazonaws.com/default/zendeskViewer?id=102487)
- Quando o vencimento de um boleto cai em um feriado, deve ser possível pagar o boleto no dia seguinte. Essa regra é aplicada no local onde se pretende pagar o boleto.

## Proposta
Adicionei as instruções necessárias para pagamento após o vencimento no próprio corpo do boleto.

**Após o vencimento, atualize seu boleto em: https://www.itau.com.br/servicos/boletos/atualizar/**

Mais a informação sobre o sobre o tempo de registro (https://github.com/vindi/aceita/issues/197): 

**Esse boleto depende do registro no banco emissor. Caso não consiga pagar imediatamente, por favor, tente mais tarde.**

Removi informações que não faziam mais sentido como `Não receber após o vencimento` e `Não receber após x dias do vencimento`

Exemplo do resultado:
![screenshot from 2018-12-28 18-56-09](https://user-images.githubusercontent.com/2758944/50527886-6119c700-0ad2-11e9-8a46-80bc6fba0e12.png)

## Critérios de aceite
- [x] Mensagem de instrução para pagamento após o vencimento no corpo do boleto.
- [x] Deve ser possível clicar no link para o site do itaú no PDF do boleto.
- [x] Mensagem sobre registro de boleto no corpo do boleto.