### PR TITLE
Add settings for Semaphore CI 2.0

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -13,6 +13,7 @@ blocks:
         - name: Setup
           commands:
             - cache restore
+            - export USER
             - export UID
             - docker-compose build
             - docker-compose run test

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -10,6 +10,7 @@ blocks:
       jobs:
         - name: Setup
           commands:
+            - checkout
             - export USER
             - export UID
             - cache restore

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -12,6 +12,8 @@ blocks:
       jobs:
         - name: Setup
           commands:
+            - cache restore
             - export UID
             - docker-compose build
             - docker-compose run test
+            - cache store

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,17 @@
+# Documentação sobre Semaphore 2.0 com Docker:
+# https://docs.semaphoreci.com/article/78-working-with-docker-images
+version: v1.0
+name: pyboleto
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: Test
+    task:
+      jobs:
+        - name: Setup
+          commands:
+            - export UID
+            - docker-compose build
+            - docker-compose run test

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,5 +1,3 @@
-# Documentação sobre Semaphore 2.0 com Docker:
-# https://docs.semaphoreci.com/article/78-working-with-docker-images
 version: v1.0
 name: pyboleto
 agent:
@@ -12,9 +10,9 @@ blocks:
       jobs:
         - name: Setup
           commands:
-            - cache restore
             - export USER
             - export UID
+            - cache restore
             - docker-compose build
             - docker-compose run test
             - cache store


### PR DESCRIPTION
## Motivação :muscle:

Habilitar o projeto para usar a versão 2.0 do Semaphore CI conforme a issue #9 

## Solução proposta :wrench:

Criar arquivo de configuração (YAML) do serviço no projeto

## Como testar :policeman:

Abrir a intrface 2.0 do Semaphore e fazer o build.

## Riscos :warning:

Sem riscos

## Impactos previstos :boom:

Sem impactos

## Requisitos para deploy :game_die:

Ter a entrada do projeto no Semaphore 2.0 criada